### PR TITLE
Update media-v2 values to match deployed config

### DIFF
--- a/talos/media-v2/values-overrides/prowlarr-values.yaml
+++ b/talos/media-v2/values-overrides/prowlarr-values.yaml
@@ -26,12 +26,35 @@ application:
 # Use specific UID/GID that matches TrueNAS NFS user
 deployment:
   serviceAccountName: media-apps
+  volumes:
+    config:
+      persistentVolumeClaim:
+        claimName: 'prowlarr-config'
+    downloads:
+      persistentVolumeClaim:
+        claimName: 'media-downloads'
+    media-library:
+      persistentVolumeClaim:
+        claimName: 'media-library'
   container:
+    image:
+      tag: '2.1.5.5216-ls131'
     env:
       - name: PUID
         value: "1000"
       - name: PGID
         value: "3001"
+    volumeMounts:
+      - name: 'config'
+        mountPath: '/config'
+      - name: 'downloads'
+        mountPath: '/downloads'
+      - name: 'media-library'
+        mountPath: '/media/film'
+        subPath: 'film'
+      - name: 'media-library'
+        mountPath: '/media/tv'
+        subPath: 'tv'
 
 ingress:
   enabled: true

--- a/talos/media-v2/values-overrides/radarr-values.yaml
+++ b/talos/media-v2/values-overrides/radarr-values.yaml
@@ -15,9 +15,6 @@ ingress:
   path: /
   pathType: Prefix
 
-# Override image version at top level
-imageTag: "5.28.0"
-
 # Configure deployment with volumes and API key sync sidecar
 deployment:
   serviceAccountName: media-apps
@@ -29,6 +26,18 @@ deployment:
     downloads:
       persistentVolumeClaim:
         claimName: 'media-downloads'
-    film:
+    media-library:
       persistentVolumeClaim:
         claimName: 'media-library'
+  # Configure volume mounts with subPath
+  container:
+    image:
+      tag: '5.28.0.10274-ls286'
+    volumeMounts:
+      - name: 'config'
+        mountPath: '/config'
+      - name: 'downloads'
+        mountPath: '/downloads'
+      - name: 'media-library'
+        mountPath: '/media/film'
+        subPath: 'film'

--- a/talos/media-v2/values-overrides/sonarr-values.yaml
+++ b/talos/media-v2/values-overrides/sonarr-values.yaml
@@ -26,7 +26,7 @@ deployment:
     downloads:
       persistentVolumeClaim:
         claimName: 'media-downloads'
-    tv:
+    media-library:
       persistentVolumeClaim:
         claimName: 'media-library'
   # Use specific UID/GID that matches TrueNAS NFS user
@@ -36,3 +36,11 @@ deployment:
         value: "1000"
       - name: PGID
         value: "3001"
+    volumeMounts:
+      - name: 'config'
+        mountPath: '/config'
+      - name: 'downloads'
+        mountPath: '/downloads'
+      - name: 'media-library'
+        mountPath: '/media/tv'
+        subPath: 'tv'


### PR DESCRIPTION
- Add explicit volume mounts with subPath for media-library
- Pin image tags for radarr (5.28.0.10274-ls286) and prowlarr (2.1.5.5216-ls131)
- Rename volume from app-specific (film/tv) to media-library for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)